### PR TITLE
feat: introduce capability to change log verbosity

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ var (
 	tlsSkipVerify         bool
 	bearerFile            string
 	forceGet              bool
+	help                  bool
 )
 
 func parseFlag() {
@@ -43,6 +44,8 @@ func parseFlag() {
 	flag.BoolVar(&tlsSkipVerify, "tlsSkipVerify", false, "Skip TLS Verification")
 	flag.StringVar(&bearerFile, "bearer-file", "", "File containing bearer token for API requests")
 	flag.BoolVar(&forceGet, "force-get", false, "Force api.Client to use GET by rejecting POST requests")
+	flag.BoolVar(&help, "help", false, "Show the usage instructions")
+	klog.InitFlags(nil)
 	flag.Parse()
 }
 
@@ -54,6 +57,12 @@ var metadataErrorRetryInterval = 1 * time.Minute
 
 func main() {
 	parseFlag()
+
+	if help {
+		flag.CommandLine.PrintDefaults()
+		return
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -281,7 +290,7 @@ func printVector(encoder expfmt.Encoder, v model.Value) {
 
 		if len(mms) > 1 {
 			// FIXME how to deal with this?
-			klog.Warningf("metric %s has multiple metadata entries, using the first one", metricName)
+			klog.V(1).Infof("metric %s has multiple metadata entries, using the first one", metricName)
 		}
 
 		// counters suffix has a special treatment. We only strip the suffix to query the metadata API


### PR DESCRIPTION
A customer's Loki is ingesting millions of log lines a day from
thanos-federate-proxy due to an inherent many-to-one mapping in
thanos-federate-proxy, which causes problems when metric families change
their declared type or documentation string. More details about how and
why metadata for a metric family changes can be found here:
https://linear.app/authzed/issue/OSS-299/fix-issue-with-thanos-federate-proxy-and-multiple-metadata-entries.

This many-to-one problem is an inherent issue in thanos-federate-proxy,
so to work around the issue of excessive logging, this commit exposes
klogs flags for controlling logging verbosity and sets the level of the
multiple-metadata warning at a level above the default verbosity of 0.

Signed-off-by: squat <lserven@gmail.com>
