### PR TITLE
Add more logging to bucket parsing errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"flag"
 	"maps"
 	"net"
@@ -396,7 +397,9 @@ func printVector(encoder expfmt.Encoder, v model.Value) {
 				lessOrEqual := sample.Metric[model.BucketLabel]
 				upperFloat, err := strconv.ParseFloat(string(lessOrEqual), 64)
 				if err != nil {
-					klog.Warningf("error parsing bucket upper bound %s on histogram %s, dropping bucket", lessOrEqual, metricName)
+					// This is coming through as empty...
+					metric, _ := json.Marshal(sample.Metric)
+					klog.Warningf("error parsing bucket upper bound %s on histogram %s, dropping bucket, raw data %s", lessOrEqual, metricName, metric)
 					continue
 				}
 


### PR DESCRIPTION
## Description
These are the log messages we're getting:

```
W0714 20:52:19.938880       1 main.go:390] error parsing bucket upper bound  on histogram grpc_server_handling_seconds, dropping bucket
W0714 20:52:19.938891       1 main.go:390] error parsing bucket upper bound  on histogram grpc_server_handling_seconds, dropping bucket
W0714 20:52:19.938903       1 main.go:390] error parsing bucket upper bound  on histogram grpc_server_handling_seconds, dropping bucket
```

This means that the upper bound is an empty string, but I don't know whether that's expected or not; logging the entire representation should help us understand that

## Changes
* Add additional logging when bucket fails to parse
## Testing
Review.