### PR TITLE
fix: gracefully skip query results with native histograms

### DIFF
--- a/main.go
+++ b/main.go
@@ -270,6 +270,14 @@ func printVector(encoder expfmt.Encoder, v model.Value) {
 			})
 		}
 
+		// Classic histograms are just regular metrics with no `Histogram` field.
+		// If a metric has a `Histogram` field, then it's a native histogram and
+		// we should skip it.
+		if sample.Histogram != nil {
+			klog.V(1).Infof("detected that metric %s is a native histogram, skipping it", metricName)
+			continue
+		}
+
 		strippedMetricName := metricName
 		isHistogramSum := strings.HasSuffix(metricName, "_sum")
 		isHistogramCount := strings.HasSuffix(metricName, "_count")


### PR DESCRIPTION
Some histograms from SpiceDB have recently started being exposed as
native histograms. When Thanos-Federate-Proxy encounters native
histograms it fails to process the query result. We need
Thanos-Federate-Proxy to fail gracefully when encountering a native
histogram so that the rest of the metrics in the query result can be
processed.

Signed-off-by: squat <lserven@gmail.com>
