### PR TITLE
fix(ci): tag container with SHA and `latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
       - uses: docker/build-push-action@v7
         with:
           file: "Dockerfile"


### PR DESCRIPTION
Before bumping the unmaintained GitHub Actions to newer versions,
containers used to be tagged with the commit SHA as well as `latest`.
This commit re-introduces that behavior.

Signed-off-by: squat <lserven@gmail.com>
